### PR TITLE
JOTL: increase container memory to 2048m

### DIFF
--- a/.github/workflows/jotl-performance.yml
+++ b/.github/workflows/jotl-performance.yml
@@ -12,4 +12,5 @@ jobs:
       target_name: jotl
       docker_image: 'ghcr.io/polykrate/jotl:latest'
       docker_cmd: '{TARGET_SOCK}'
+      docker_memory: '2048m'
       readiness_pattern: 'Listening on'


### PR DESCRIPTION
SBCL needs a larger heap for 128 live states (fork support) and bounded GC pauses. The startup script auto-sizes the heap to 75% of the container limit.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced performance testing infrastructure by allocating additional memory resources to the Docker environment, enabling more stable and efficient test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->