### PR TITLE
Deploy dashboard from cron

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -1,24 +1,8 @@
 name: Deploy Dashboard
 
 on:
-  # Run after any performance workflow completes
-  workflow_run:
-    workflows:
-      - "Performance: typeberry"
-      - "Performance: boka"
-      - "Performance: graymatter"
-      - "Performance: jam4s"
-      - "Performance: jamforge"
-      - "Performance: javajam"
-      - "Performance: pbnjam"
-      - "Performance: pyjamaz"
-      - "Performance: turbojam"
-      - "Performance: jamzilla"
-      - "Performance: jamzilla-int"
-      - "Performance: jotl"
-      - "Performance: jampy"
-      - "Performance: new-jamneration"
-    types: [completed]
+  schedule:
+    - cron: '0 8,20 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dashboard deployment workflow now triggers on a schedule (twice daily) instead of in response to other workflow completions, with manual deployment still available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->