### PR TITLE
Increase pbnjam docker memory to 4096m

### DIFF
--- a/.github/workflows/pbnjam-fuzz.yml
+++ b/.github/workflows/pbnjam-fuzz.yml
@@ -13,4 +13,5 @@ jobs:
       target_name: pbnjam
       docker_image: 'shimonchick/pbnjam-fuzzer-target:latest'
       docker_cmd: '--socket {TARGET_SOCK}'
+      docker_memory: '4096m'
       mention: mikirov

--- a/.github/workflows/pbnjam-performance.yml
+++ b/.github/workflows/pbnjam-performance.yml
@@ -15,3 +15,4 @@ jobs:
       target_name: pbnjam
       docker_image: 'shimonchick/pbnjam-fuzzer-target:latest'
       docker_cmd: '--socket {TARGET_SOCK}'
+      docker_memory: '4096m'


### PR DESCRIPTION
Closes: #13

## Summary
- Set `docker_memory: '4096m'` for both pbnjam fuzz and performance workflows
- The pbnjam target needs ~3.5 GB RAM for native bindings ring proof verification, which preloads and caches data in-memory
- Previously using defaults (2048m for fuzz, 512m for performance), which were insufficient

## Test plan
- [ ] Verify pbnjam fuzz workflow runs without OOM kills
- [ ] Verify pbnjam performance workflow runs without OOM kills

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased Docker memory allocation to 4GB in fuzz testing and performance testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->