### PR TITLE
Use jamzilla:edge image instead of jamzilla-tiny:edge

### DIFF
--- a/.github/workflows/jamzilla-fuzz.yml
+++ b/.github/workflows/jamzilla-fuzz.yml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/demo-source.yml
     with:
       target_name: jamzilla
-      docker_image: 'ghcr.io/ascrivener/jamzilla-tiny:edge'
+      docker_image: 'ghcr.io/ascrivener/jamzilla:edge'
       docker_cmd: '-socket {TARGET_SOCK}'
       docker_env: 'PVM_MODE=jit'
       mention: ascrivener

--- a/.github/workflows/jamzilla-int-fuzz.yml
+++ b/.github/workflows/jamzilla-int-fuzz.yml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/demo-source.yml
     with:
       target_name: jamzilla-int
-      docker_image: 'ghcr.io/ascrivener/jamzilla-tiny:edge'
+      docker_image: 'ghcr.io/ascrivener/jamzilla:edge'
       docker_cmd: '-socket {TARGET_SOCK}'
       docker_env: 'PVM_MODE=interpreter'
       mention: ascrivener

--- a/.github/workflows/jamzilla-int-performance.yml
+++ b/.github/workflows/jamzilla-int-performance.yml
@@ -13,6 +13,6 @@ jobs:
     uses: ./.github/workflows/reusable-picofuzz.yml
     with:
       target_name: jamzilla-int
-      docker_image: 'ghcr.io/ascrivener/jamzilla-tiny:edge'
+      docker_image: 'ghcr.io/ascrivener/jamzilla:edge'
       docker_cmd: '-socket {TARGET_SOCK}'
       docker_env: 'PVM_MODE=interpreter'

--- a/.github/workflows/jamzilla-performance.yml
+++ b/.github/workflows/jamzilla-performance.yml
@@ -13,6 +13,6 @@ jobs:
     uses: ./.github/workflows/reusable-picofuzz.yml
     with:
       target_name: jamzilla
-      docker_image: 'ghcr.io/ascrivener/jamzilla-tiny:edge'
+      docker_image: 'ghcr.io/ascrivener/jamzilla:edge'
       docker_cmd: '-socket {TARGET_SOCK}'
       docker_env: 'PVM_MODE=jit'


### PR DESCRIPTION
Updates the four jamzilla workflows to point at `ghcr.io/ascrivener/jamzilla:edge` instead of `ghcr.io/ascrivener/jamzilla-tiny:edge`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container image references in CI/CD workflows from minimal to full-featured variants across fuzzing and performance testing pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->