### PR TITLE
Drop docker_cmd for graymatter; rely on JAM_FUZZ_* env vars

### DIFF
--- a/.github/workflows/demo-source.yml
+++ b/.github/workflows/demo-source.yml
@@ -12,9 +12,10 @@ on:
         type: string
         description: "Full Docker image reference for the target"
       docker_cmd:
-        required: true
+        required: false
         type: string
-        description: "Target command with {TARGET_SOCK} placeholder"
+        default: ""
+        description: "Target command with {TARGET_SOCK} placeholder. Leave empty for targets that read JAM_FUZZ_SOCK_PATH from env."
       docker_env:
         required: false
         type: string

--- a/.github/workflows/graymatter-fuzz.yml
+++ b/.github/workflows/graymatter-fuzz.yml
@@ -18,5 +18,4 @@ jobs:
     with:
       target_name: graymatter
       docker_image: 'ghcr.io/jambrains/graymatter/gm:conformance-fuzzer-latest'
-      docker_cmd: 'fuzz-m1-target --stay-open --listen {TARGET_SOCK}'
       mention: franciscoaguirre

--- a/tests/common.ts
+++ b/tests/common.ts
@@ -91,16 +91,15 @@ export interface TargetConfig {
 export function getTargetConfig(): TargetConfig {
   const name = process.env.TARGET_NAME;
   const image = process.env.TARGET_IMAGE;
-  const cmd = process.env.TARGET_CMD;
 
-  if (!name || !image || !cmd) {
-    throw new Error("TARGET_NAME, TARGET_IMAGE, and TARGET_CMD environment variables are required");
+  if (!name || !image) {
+    throw new Error("TARGET_NAME and TARGET_IMAGE environment variables are required");
   }
 
   return {
     name,
     image,
-    cmd,
+    cmd: process.env.TARGET_CMD || "",
     env: process.env.TARGET_ENV || "",
     readinessPattern: process.env.TARGET_READINESS_PATTERN || "",
     memory: process.env.TARGET_MEMORY || "512m",


### PR DESCRIPTION
## Summary
- Graymatter target fails when started with the legacy \`fuzz-m1-target --stay-open --listen {TARGET_SOCK}\` args, so launch it with no cmd args and let it pick up \`JAM_FUZZ\`, \`JAM_FUZZ_SOCK_PATH\`, etc. from the standard target packaging env vars added in #33.
- Make \`docker_cmd\` optional (default \`\"\"\`) in \`demo-source.yml\`; \`tests/common.ts\` no longer requires \`TARGET_CMD\` (\`buildCmdArgs(\"\")\` already collapses to no args).
- Other targets are unchanged for now — only graymatter is migrated in this PR.

## Test plan
- [ ] Trigger \`Fuzz: graymatter\` via workflow_dispatch and confirm the demo job starts the target, the socket appears, and fuzz-m1-source completes.
- [ ] Trigger one untouched fuzz workflow (e.g. \`Fuzz: jampy\`) to confirm \`docker_cmd\`-using callers still work after the input was made optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made docker command configuration optional in workflows and tests, allowing targets to read socket path from environment variables when no explicit command is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->