### PR TITLE
Bump upload-pages-artifact and deploy-pages from v4 to v5

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -121,10 +121,10 @@ jobs:
         run: npm run build
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dashboard/out
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- Bumps `actions/upload-pages-artifact` and `actions/deploy-pages` from v4 to v5 in `deploy-dashboard.yml`.
- The v4 releases run on Node.js 20, which is deprecated on GitHub Actions runners (will be forced to Node.js 24 by default starting June 2nd, 2026, and removed entirely on September 16th, 2026). v5 moves both actions to Node.js 24 and clears the deprecation warning seen in recent runs.
- All other actions used in this repo (`checkout@v6`, `setup-node@v6`, `upload-artifact@v7`) are already on their latest major.

## Test plan
- [ ] Next scheduled "Deploy Dashboard" run (or a manual `workflow_dispatch`) completes without the Node.js 20 deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure dependencies to latest versions for improved reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->