### PR TITLE
Drop docker_cmd for graymatter performance

### DIFF
--- a/.github/workflows/graymatter-performance.yml
+++ b/.github/workflows/graymatter-performance.yml
@@ -14,4 +14,3 @@ jobs:
     with:
       target_name: graymatter
       docker_image: 'ghcr.io/jambrains/graymatter/gm:conformance-fuzzer-latest'
-      docker_cmd: 'fuzz-m1-target --stay-open --listen {TARGET_SOCK}'

--- a/.github/workflows/reusable-picofuzz.yml
+++ b/.github/workflows/reusable-picofuzz.yml
@@ -12,9 +12,10 @@ on:
         type: string
         description: "Full Docker image reference"
       docker_cmd:
-        required: true
+        required: false
         type: string
-        description: "Base command with {TARGET_SOCK} placeholder"
+        default: ""
+        description: "Base command with {TARGET_SOCK} placeholder. Leave empty for targets that read JAM_FUZZ_SOCK_PATH from env."
       docker_env:
         required: false
         type: string


### PR DESCRIPTION
## Summary

- Drop `docker_cmd` from `graymatter-performance.yml`; the graymatter image rejects the legacy `fuzz-m1-target` CLI args and reads `JAM_FUZZ_SOCK_PATH` etc. from env vars (added in #33).
- Make `docker_cmd` optional (default `""`) in `reusable-picofuzz.yml`, matching the change applied to `demo-source.yml` in #35.

Mirrors #35 for the performance job.

## Test plan

- [ ] Confirm scheduled `Performance: graymatter` workflow run starts the target with no CLI args and completes minifuzz + picofuzz suites.
- [ ] Confirm other targets' performance workflows (which still set `docker_cmd`) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to improve build configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->