### PR TITLE
Align docker_cmd contract across docs, workflows, and CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,20 +17,188 @@ reviews:
         1. The `name:` field follows the exact pattern `"Performance: <team>"`.
         2. The filename matches `<team>-performance.yml`.
         3. It uses `uses: ./.github/workflows/reusable-picofuzz.yml`.
-        4. Required inputs are provided: `target_name`, `docker_image`, `docker_cmd`.
+        4. Required inputs are provided: `target_name`, `docker_image`. `docker_cmd`
+           is OPTIONAL — new targets that read `JAM_FUZZ_SOCK_PATH` from env can omit
+           it and rely on the image's default `CMD`. Do not request changes solely for
+           a missing `docker_cmd`.
         5. The `target_name` value matches the `<team>` in the filename and workflow name.
         6. It has both `schedule` (cron) and `workflow_dispatch` triggers.
         7. The Docker image reference looks like a public registry path (e.g. ghcr.io).
-        8. The `docker_cmd` contains the `{TARGET_SOCK}` placeholder.
+        8. If `docker_cmd` is provided, it should contain the `{TARGET_SOCK}` placeholder
+           (which is substituted with the socket path). If `docker_cmd` is absent, this
+           check does not apply.
         9. No extra jobs or steps are added beyond `uses: ./.github/workflows/reusable-picofuzz.yml`.
         10. A corresponding `teams/<team>/` directory with a `.gitkeep` file MUST exist
             in the same PR. Without it the dashboard will silently skip this team's data.
             If the directory is missing, request changes.
         11. The Docker image must be publicly accessible (no authentication required).
-            Check that the image reference points to a public ghcr.io or Docker Hub
-            repository. If the image is under a private org or user namespace, flag it
-            as a potential issue — the workflow will fail with "unauthorized" at runtime
-            if the image cannot be pulled without credentials.
+            Apply the "Docker image availability check" protocol below — DO NOT flag
+            based on namespace heuristics, and DO NOT flag without ≥2 independent
+            verification attempts that consistently report a definitive missing-image
+            response.
+
+        Docker image availability check protocol:
+
+        STRICT ANTI-FALSE-POSITIVE POLICY. Read this in full before flagging
+        any image as unavailable. False positives on this check are MUCH
+        worse than false negatives, because the workflow itself will fail
+        loudly at runtime if the image truly is unavailable — so the
+        downside of missing one is bounded and self-correcting, while
+        falsely blocking a legitimate PR wastes contributor time and
+        erodes trust in this review.
+
+        Default behavior: DO NOT FLAG. Only raise the concern when you have
+        STRONG, REPRODUCIBLE evidence the image cannot be pulled anonymously.
+
+        Verification protocol — perform ALL applicable steps before flagging:
+
+        (a) Do NOT rely on namespace heuristics. A "personal-looking" GitHub
+            user namespace (e.g. `ghcr.io/<username>/...`), an unfamiliar
+            registry, or a non-standard image name is NOT evidence of being
+            private. Many legitimate teams publish public images under
+            personal namespaces. Skin-deep cues are off-limits as the basis
+            for a comment.
+
+        (b) Perform AT LEAST TWO independent verification attempts before
+            drawing any conclusion. Examples of independent methods:
+            - `docker manifest inspect <image>` (anonymous).
+            - `curl -sI https://<registry>/v2/<repo>/manifests/<tag>` after
+              negotiating an anonymous bearer token from the registry's
+              `WWW-Authenticate` header (this is the standard OCI dance —
+              a 401 on the first request is EXPECTED and is NOT evidence
+              of private-ness; you must follow the auth challenge).
+            - `gh api` against ghcr.io for ghcr-hosted images.
+            - The registry's web UI (e.g. https://github.com/orgs/<org>/packages
+              or https://hub.docker.com/r/<repo>).
+            Two attempts using the SAME method don't count as independent —
+            use at least two genuinely different paths. If you can manage
+            three independent methods, even better.
+
+        (c) Classify failure modes correctly. ONLY a definitive 404 /
+            "manifest unknown" / "name unknown" / "repository does not
+            exist" — observed CONSISTENTLY across BOTH attempts — counts
+            as evidence the image is missing. Specifically:
+
+            - HTTP 401 / "unauthorized" alone is NOT evidence. Public
+              registries return 401 on the first request and expect the
+              client to negotiate an anonymous token. If you saw a 401,
+              you almost certainly skipped the auth dance — retry
+              correctly before drawing any conclusion.
+            - HTTP 5xx, timeouts, DNS errors, rate-limit (429) responses,
+              connection resets — TRANSIENT. Treat as "ok". Do NOT flag.
+            - Any inability to run the check at all (no network, no docker,
+              tool not available) — INCONCLUSIVE. Treat as "ok". Do NOT
+              flag.
+
+        (d) If — and ONLY if — after ≥2 independent attempts using genuinely
+            different methods you get a consistent definitive missing-image
+            response (404 / manifest unknown), raise it as a QUESTION, not
+            a request-changes:
+
+              "I tried to pull `<image>` using <method 1> and <method 2>
+               and both reported the manifest is unknown. Could you
+               double-check the image reference and confirm it's pushed
+               and publicly accessible?"
+
+            Frame it as a check-with-the-author, not as a blocker. The
+            author may know something you don't (e.g. the image is being
+            pushed in a follow-up commit).
+
+        Reminder: when in doubt, say nothing. The CI will catch a truly
+        broken reference within minutes of the first run.
+
+    # --- Per-team fuzz workflow ---
+    - path: ".github/workflows/*-fuzz.yml"
+      instructions: |
+        This is a per-team fuzz workflow. Verify:
+        1. The `name:` field follows the exact pattern `"Fuzz: <team>"`.
+        2. The filename matches `<team>-fuzz.yml`.
+        3. It uses one of `./.github/workflows/graymatter-fuzz-source.yml`,
+           `./.github/workflows/demo-source.yml`, or another reusable fuzz
+           source workflow in `.github/workflows/`.
+        4. Required inputs are provided: `target_name`, `docker_image`. `docker_cmd`
+           is OPTIONAL — new targets that read `JAM_FUZZ_SOCK_PATH` from env can omit
+           it and rely on the image's default `CMD`. Do not request changes solely for
+           a missing `docker_cmd`.
+        5. The `target_name` value matches the `<team>` in the filename and workflow name.
+        6. If `docker_cmd` is provided, it should contain the `{TARGET_SOCK}` placeholder.
+        7. `mention` should be set to a valid GitHub username — without it, no
+           failure issue is created. This is a soft recommendation, not a blocker.
+        8. The Docker image must be publicly accessible (no authentication required).
+           Apply the "Docker image availability check" protocol below — DO NOT flag
+           based on namespace heuristics, and DO NOT flag without ≥2 independent
+           verification attempts that consistently report a definitive missing-image
+           response.
+
+        Docker image availability check protocol:
+
+        STRICT ANTI-FALSE-POSITIVE POLICY. Read this in full before flagging
+        any image as unavailable. False positives on this check are MUCH
+        worse than false negatives, because the workflow itself will fail
+        loudly at runtime if the image truly is unavailable — so the
+        downside of missing one is bounded and self-correcting, while
+        falsely blocking a legitimate PR wastes contributor time and
+        erodes trust in this review.
+
+        Default behavior: DO NOT FLAG. Only raise the concern when you have
+        STRONG, REPRODUCIBLE evidence the image cannot be pulled anonymously.
+
+        Verification protocol — perform ALL applicable steps before flagging:
+
+        (a) Do NOT rely on namespace heuristics. A "personal-looking" GitHub
+            user namespace (e.g. `ghcr.io/<username>/...`), an unfamiliar
+            registry, or a non-standard image name is NOT evidence of being
+            private. Many legitimate teams publish public images under
+            personal namespaces. Skin-deep cues are off-limits as the basis
+            for a comment.
+
+        (b) Perform AT LEAST TWO independent verification attempts before
+            drawing any conclusion. Examples of independent methods:
+            - `docker manifest inspect <image>` (anonymous).
+            - `curl -sI https://<registry>/v2/<repo>/manifests/<tag>` after
+              negotiating an anonymous bearer token from the registry's
+              `WWW-Authenticate` header (this is the standard OCI dance —
+              a 401 on the first request is EXPECTED and is NOT evidence
+              of private-ness; you must follow the auth challenge).
+            - `gh api` against ghcr.io for ghcr-hosted images.
+            - The registry's web UI (e.g. https://github.com/orgs/<org>/packages
+              or https://hub.docker.com/r/<repo>).
+            Two attempts using the SAME method don't count as independent —
+            use at least two genuinely different paths. If you can manage
+            three independent methods, even better.
+
+        (c) Classify failure modes correctly. ONLY a definitive 404 /
+            "manifest unknown" / "name unknown" / "repository does not
+            exist" — observed CONSISTENTLY across BOTH attempts — counts
+            as evidence the image is missing. Specifically:
+
+            - HTTP 401 / "unauthorized" alone is NOT evidence. Public
+              registries return 401 on the first request and expect the
+              client to negotiate an anonymous token. If you saw a 401,
+              you almost certainly skipped the auth dance — retry
+              correctly before drawing any conclusion.
+            - HTTP 5xx, timeouts, DNS errors, rate-limit (429) responses,
+              connection resets — TRANSIENT. Treat as "ok". Do NOT flag.
+            - Any inability to run the check at all (no network, no docker,
+              tool not available) — INCONCLUSIVE. Treat as "ok". Do NOT
+              flag.
+
+        (d) If — and ONLY if — after ≥2 independent attempts using genuinely
+            different methods you get a consistent definitive missing-image
+            response (404 / manifest unknown), raise it as a QUESTION, not
+            a request-changes:
+
+              "I tried to pull `<image>` using <method 1> and <method 2>
+               and both reported the manifest is unknown. Could you
+               double-check the image reference and confirm it's pushed
+               and publicly accessible?"
+
+            Frame it as a check-with-the-author, not as a blocker. The
+            author may know something you don't (e.g. the image is being
+            pushed in a follow-up commit).
+
+        Reminder: when in doubt, say nothing. The CI will catch a truly
+        broken reference within minutes of the first run.
 
     # --- Dashboard deploy workflow ---
     - path: ".github/workflows/deploy-dashboard.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "ci-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm exec tsx -- --test tests/config.test.ts

--- a/.github/workflows/graymatter-fuzz-source.yml
+++ b/.github/workflows/graymatter-fuzz-source.yml
@@ -12,9 +12,10 @@ on:
         type: string
         description: "Full Docker image reference for the target"
       docker_cmd:
-        required: true
+        required: false
         type: string
-        description: "Target command with {TARGET_SOCK} placeholder"
+        default: ""
+        description: "Target command with {TARGET_SOCK} placeholder. Leave empty for targets that read JAM_FUZZ_SOCK_PATH from env."
       docker_env:
         required: false
         type: string

--- a/README.md
+++ b/README.md
@@ -97,11 +97,12 @@ connections on the Unix socket. Two modes are supported:
    env vars on every target container: `JAM_FUZZ=1`, `JAM_FUZZ_SPEC=tiny`,
    `JAM_FUZZ_DATA_PATH=/shared/data`, `JAM_FUZZ_SOCK_PATH=/shared/jam_target.sock`,
    `JAM_FUZZ_LOG_LEVEL=debug`.
-   New targets should read the socket path from `JAM_FUZZ_SOCK_PATH`. For
-   backwards compatibility, the legacy `{TARGET_SOCK}` placeholder in
-   `docker_cmd` is still substituted with the same socket path, so existing
-   targets keep working unchanged. Anything in `docker_env` is appended after
-   the standard vars and can override them.
+   New targets should read the socket path from `JAM_FUZZ_SOCK_PATH` and can
+   be launched with their image's default `CMD` — leave `docker_cmd` unset in
+   that case. For backwards compatibility, when `docker_cmd` is provided the
+   legacy `{TARGET_SOCK}` placeholder is substituted with the same socket
+   path, so existing targets keep working unchanged. Anything in `docker_env`
+   is appended after the standard vars and can override them.
    `JAM_FUZZ_DATA_PATH` is wiped between sequential fuzz-source runs to match
    official testing's fresh-init behavior.
 
@@ -121,8 +122,8 @@ connections on the Unix socket. Two modes are supported:
        with:
          target_name: myteam
          docker_image: 'ghcr.io/myorg/myimage:latest'
-         docker_cmd: 'fuzz --socket {TARGET_SOCK}'
          # Optional overrides:
+         # docker_cmd: 'fuzz --socket {TARGET_SOCK}'   # only if your image needs args; new targets read JAM_FUZZ_SOCK_PATH
          # docker_env: 'MY_VAR=value'
          # docker_memory: '512m'
          # docker_platform: 'linux/amd64'
@@ -141,13 +142,14 @@ connections on the Unix socket. Two modes are supported:
 |---|---|---|---|
 | `target_name` | yes | — | Your implementation name |
 | `docker_image` | yes | — | Full image reference |
-| `docker_cmd` | yes | — | Command with `{TARGET_SOCK}` placeholder for the socket path |
+| `docker_cmd` | no | `""` | Override container command. `{TARGET_SOCK}` is substituted with the socket path. Leave empty for targets that read `JAM_FUZZ_SOCK_PATH` from env. |
 | `docker_env` | no | `""` | Space-separated `KEY=VALUE` pairs passed as `-e` flags |
 | `docker_memory` | no | `"512m"` | Container memory limit |
 | `docker_platform` | no | `"linux/amd64"` | Platform for `docker pull` |
 | `readiness_pattern` | no | `""` | Regex matched against stdout to detect readiness |
 | `timeout_minutes` | no | `10` | Per-suite timeout |
 | `test_suites` | no | all four | JSON array of picofuzz suite names to run |
+| `minifuzz_suites` | no | all six | JSON array of minifuzz suite names to run |
 
 ## Running locally
 
@@ -174,14 +176,14 @@ npx tsx --test tests/picofuzz/fallback.test.ts
 
 ### Environment variables
 
-| Variable | Description |
-|---|---|
-| `TARGET_NAME` | Implementation name |
-| `TARGET_IMAGE` | Docker image to test |
-| `TARGET_CMD` | Container command (`{TARGET_SOCK}` is replaced with the socket path) |
-| `TARGET_ENV` | Space-separated `KEY=VALUE` pairs |
-| `TARGET_MEMORY` | Container memory limit (default `512m`) |
-| `TARGET_READINESS_PATTERN` | Regex for log-based readiness |
+| Variable | Required | Description |
+|---|---|---|
+| `TARGET_NAME` | yes | Implementation name |
+| `TARGET_IMAGE` | yes | Docker image to test |
+| `TARGET_CMD` | no | Container command override (`{TARGET_SOCK}` is replaced with the socket path). Empty/unset uses the image's default `CMD`. |
+| `TARGET_ENV` | no | Space-separated `KEY=VALUE` pairs |
+| `TARGET_MEMORY` | no | Container memory limit (default `512m`) |
+| `TARGET_READINESS_PATTERN` | no | Regex for log-based readiness; default is socket-probe |
 
 ## Regenerating minifuzz traces
 

--- a/agents.md
+++ b/agents.md
@@ -40,8 +40,8 @@ jobs:
     with:
       target_name: <team>
       docker_image: '<registry>/<image>:<tag>'
-      docker_cmd: '<command> {TARGET_SOCK}'
-      # Optional:
+      # Optional (only required inputs are target_name and docker_image):
+      # docker_cmd: '<command> {TARGET_SOCK}'   # only if your image needs args; new targets can rely on JAM_FUZZ_SOCK_PATH
       # docker_env: 'KEY=VALUE KEY2=VALUE2'
       # docker_memory: '512m'
       # docker_platform: 'linux/amd64'
@@ -86,13 +86,14 @@ jobs:
     with:
       target_name: <team>
       docker_image: '<registry>/<image>:<tag>'
-      docker_cmd: '<command> {TARGET_SOCK}'
-      # Optional:
+      mention: <github-username>
+      # Optional (only required inputs are target_name and docker_image; mention is technically
+      # optional but recommended — without it no failure issue is created):
+      # docker_cmd: '<command> {TARGET_SOCK}'   # only if your image needs args; new targets can rely on JAM_FUZZ_SOCK_PATH
       # docker_env: 'KEY=VALUE KEY2=VALUE2'
       # docker_memory: '512m'
       # docker_platform: 'linux/amd64'
       # readiness_pattern: 'Ready'
-      mention: <github-username>
 ```
 
 Copy the structure from `typeberry-fuzz.yml`.
@@ -170,6 +171,8 @@ npm run build -w @fluffylabs/minifuzz
 docker pull --platform=linux/amd64 <target-image>
 mkdir -p ./picofuzz-result
 
+# TARGET_CMD is optional — omit if the image's CMD reads JAM_FUZZ_SOCK_PATH.
+# TARGET_READINESS_PATTERN is optional — default is socket-probe.
 TARGET_NAME=<team> \
 TARGET_IMAGE='<image>' \
 TARGET_CMD='<cmd> {TARGET_SOCK}' \

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -7,7 +7,7 @@ describe("getTargetConfig", () => {
     delete process.env.TARGET_NAME;
     delete process.env.TARGET_IMAGE;
     delete process.env.TARGET_CMD;
-    assert.throws(() => getTargetConfig(), /TARGET_NAME, TARGET_IMAGE, and TARGET_CMD/);
+    assert.throws(() => getTargetConfig(), /TARGET_NAME and TARGET_IMAGE/);
   });
 
   it("parses env vars correctly", () => {
@@ -30,12 +30,13 @@ describe("getTargetConfig", () => {
   it("uses defaults for optional fields", () => {
     process.env.TARGET_NAME = "minimal";
     process.env.TARGET_IMAGE = "img:v1";
-    process.env.TARGET_CMD = "run {TARGET_SOCK}";
+    delete process.env.TARGET_CMD;
     delete process.env.TARGET_ENV;
     delete process.env.TARGET_MEMORY;
     delete process.env.TARGET_READINESS_PATTERN;
 
     const config = getTargetConfig();
+    assert.strictEqual(config.cmd, "");
     assert.strictEqual(config.env, "");
     assert.strictEqual(config.memory, "512m");
     assert.strictEqual(config.readinessPattern, "");


### PR DESCRIPTION
## Summary

The actual code has treated `docker_cmd` as optional since #33/#35/#37, but several places still claimed it was required — including the CodeRabbit rule, which was generating false-positive review comments on PRs. This PR aligns docs, the one inconsistent reusable workflow, the CodeRabbit config, and a stale unit test that was failing without anyone noticing.

- **Docs (`README.md`, `agents.md`)** — mark `docker_cmd` / `TARGET_CMD` as optional with `""` default; drop it from the headline templates and move it into the optional-overrides block. Updated the narrative around the standard target packaging env vars.
- **`.coderabbit.yaml`** — stop telling the bot to flag missing `docker_cmd`. Replace the namespace-based "image must be public" heuristic (which generated false positives on PRs using personal-namespace public images) with a strict **anti-false-positive verification protocol**: require ≥2 *independent* checks via different methods, distinguish 401 / transient / definitive-404 failure modes, default to silence, frame any final comment as a question rather than a request-changes. Same protocol added to a new `*-fuzz.yml` rule block (which previously had no rules at all).
- **`.github/workflows/graymatter-fuzz-source.yml`** — was the only remaining reusable workflow still declaring `docker_cmd: required: true`. Flipped to `required: false` with `default: ""` so all three reusable workflows (`reusable-picofuzz.yml`, `demo-source.yml`, `graymatter-fuzz-source.yml`) now share the same contract. Existing callers (`typeberry-fuzz.yml`, `turbojam-fuzz.yml`) pass `docker_cmd` explicitly, so this is backwards-compatible — no functional change for any current target.
- **`tests/config.test.ts`** — orphaned by #35: it asserted the old `"TARGET_NAME, TARGET_IMAGE, and TARGET_CMD"` error string and was silently failing locally. Updated the regex and switched the "uses defaults" case to actually exercise the optional `TARGET_CMD`.
- **`.github/workflows/ci.yml` (new)** — minimal CI workflow on `ubuntu-latest` that runs `tests/config.test.ts` on every PR and push to `main`. The reason `config.test.ts` stayed broken was that *no* workflow ever ran it; this closes that gap. (Did not also wire up `npm run qa`/biome — it currently has 8 pre-existing errors on `main` that would block every PR; cleanup can be a follow-up.)

## Test plan

- [x] `npm exec tsx -- --test tests/config.test.ts` — 3/3 pass locally
- [x] `python3 -c 'import yaml; yaml.safe_load(open(".coderabbit.yaml"))'` — YAML is valid, no duplicate path entries
- [x] All three reusable workflows (`reusable-picofuzz.yml`, `demo-source.yml`, `graymatter-fuzz-source.yml`) declare `docker_cmd` identically (`required: false`, `default: ""`)
- [ ] On merge: confirm the new `CI / Unit tests` job runs and is green
- [ ] On a future new-team PR: confirm CodeRabbit no longer flags missing `docker_cmd` and is appropriately quiet about image availability

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated CI pipeline for running unit tests on pull requests and branch pushes.

* **Chores**
  * Docker command parameter is now optional; targets can read socket paths from environment variables instead.
  * Updated documentation with clearer guidance on optional configuration parameters.
  * Refined workflow review policies for stricter validation protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->