### PR TITLE
Bump jamduna performance memory to 2048m

### DIFF
--- a/.github/workflows/jamduna-performance.yml
+++ b/.github/workflows/jamduna-performance.yml
@@ -14,3 +14,4 @@ jobs:
     with:
       target_name: jamduna
       docker_image: 'ghcr.io/jam-duna/duna-target:latest'
+      docker_memory: '2048m'


### PR DESCRIPTION
## Summary
- Override the default 512m Docker memory limit for the jamduna performance test, raising it to 2048m to match what jamduna already gets in the fuzz workflow.

## Test plan
- [ ] Watch the next scheduled / dispatched jamduna performance run to confirm minifuzz and picofuzz jobs start with the new memory limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)