### PR TITLE
Bump CI memory limits for performance and demo (full) targets

### DIFF
--- a/.github/workflows/boka-demo-full.yml
+++ b/.github/workflows/boka-demo-full.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       target_name: boka
       docker_image: 'acala/boka:latest'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: xlc

--- a/.github/workflows/graymatter-demo-full.yml
+++ b/.github/workflows/graymatter-demo-full.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       target_name: graymatter
       docker_image: 'ghcr.io/jambrains/graymatter/gm:conformance-fuzzer-latest'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: franciscoaguirre

--- a/.github/workflows/jam4s-demo-full.yml
+++ b/.github/workflows/jam4s-demo-full.yml
@@ -20,7 +20,7 @@ jobs:
       target_name: jam4s
       docker_image: 'jamforscala/jam4s:0.7.2-rc.11-amd64'
       docker_env: 'CONFIG_FILE=app/config/node-dev.conf'
-      docker_memory: '4096m'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: celadari

--- a/.github/workflows/jambda-demo-full.yml
+++ b/.github/workflows/jambda-demo-full.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       target_name: jambda
       docker_image: 'ghcr.io/archelabs/jambda-fuzz-target:latest'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: libingjiang47

--- a/.github/workflows/jambda-performance.yml
+++ b/.github/workflows/jambda-performance.yml
@@ -14,3 +14,4 @@ jobs:
     with:
       target_name: jambda
       docker_image: 'ghcr.io/archelabs/jambda-fuzz-target:latest'
+      docker_memory: '2048m'

--- a/.github/workflows/jamduna-demo-full.yml
+++ b/.github/workflows/jamduna-demo-full.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       target_name: jamduna
       docker_image: 'ghcr.io/jam-duna/duna-target:latest'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: mkchungs

--- a/.github/workflows/jamforge-demo-full.yml
+++ b/.github/workflows/jamforge-demo-full.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       target_name: jamforge
       docker_image: 'ghcr.io/philoniare/jam-forge:latest'
-      docker_memory: '4096m'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: philoniare

--- a/.github/workflows/jamixir-demo-full.yml
+++ b/.github/workflows/jamixir-demo-full.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       target_name: jamixir
       docker_image: 'ghcr.io/jamixir/jamixir:0.7.2'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: danicuki

--- a/.github/workflows/jampy-demo-full.yml
+++ b/.github/workflows/jampy-demo-full.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       target_name: jampy
       docker_image: 'ghcr.io/dakk/jampy-target:0.7.2'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: dakk

--- a/.github/workflows/jampy-recompiler-demo-full.yml
+++ b/.github/workflows/jampy-recompiler-demo-full.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       target_name: jampy-recompiler
       docker_image: 'ghcr.io/dakk/jampy-target:0.7.2'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: dakk

--- a/.github/workflows/jamzig-demo-full.yml
+++ b/.github/workflows/jamzig-demo-full.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       target_name: jamzig
       docker_image: 'docker.io/jamzig/jam-conformance-target:latest'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: boymaas

--- a/.github/workflows/jamzilla-demo-full.yml
+++ b/.github/workflows/jamzilla-demo-full.yml
@@ -20,6 +20,7 @@ jobs:
       target_name: jamzilla
       docker_image: 'ghcr.io/ascrivener/jamzilla:edge'
       docker_env: 'PVM_MODE=jit'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: ascrivener

--- a/.github/workflows/jamzilla-int-demo-full.yml
+++ b/.github/workflows/jamzilla-int-demo-full.yml
@@ -20,6 +20,7 @@ jobs:
       target_name: jamzilla-int
       docker_image: 'ghcr.io/ascrivener/jamzilla:edge'
       docker_env: 'PVM_MODE=interpreter'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: ascrivener

--- a/.github/workflows/jotl-demo-full.yml
+++ b/.github/workflows/jotl-demo-full.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       target_name: jotl
       docker_image: 'ghcr.io/polykrate/jotl:latest'
-      docker_memory: '2048m'
+      docker_memory: '8192m'
       readiness_pattern: 'Listening on'
       spec: full
       num_blocks: 500

--- a/.github/workflows/new-jamneration-demo-full.yml
+++ b/.github/workflows/new-jamneration-demo-full.yml
@@ -20,6 +20,7 @@ jobs:
       target_name: new-jamneration
       docker_image: 'ghcr.io/new-jamneration/new-jamneration-target:latest'
       docker_env: 'USE_MINI_REDIS=true'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: YCC3741

--- a/.github/workflows/pbnjam-demo-full.yml
+++ b/.github/workflows/pbnjam-demo-full.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       target_name: pbnjam
       docker_image: 'shimonchick/pbnjam-fuzzer-target:latest'
-      docker_memory: '4096m'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: mikirov

--- a/.github/workflows/pyjamaz-demo-full.yml
+++ b/.github/workflows/pyjamaz-demo-full.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       target_name: pyjamaz
       docker_image: 'jamdottech/pyjamaz:latest'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: emielsebastiaan

--- a/.github/workflows/spacejam-demo-full.yml
+++ b/.github/workflows/spacejam-demo-full.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       target_name: spacejam
       docker_image: 'clearloop/spacejam:latest'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: clearloop

--- a/.github/workflows/spacejam-performance.yml
+++ b/.github/workflows/spacejam-performance.yml
@@ -14,3 +14,4 @@ jobs:
     with:
       target_name: spacejam
       docker_image: 'clearloop/spacejam:latest'
+      docker_memory: '2048m'

--- a/.github/workflows/tessera-demo-full.yml
+++ b/.github/workflows/tessera-demo-full.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       target_name: tessera
       docker_image: 'ghcr.io/chainscore/tessera:latest'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: prasad-kumkar

--- a/.github/workflows/tsjam-demo-full.yml
+++ b/.github/workflows/tsjam-demo-full.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       target_name: tsjam
       docker_image: 'ghcr.io/vekexasia/tsjam-target:0.7.2'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: vekexasia

--- a/.github/workflows/turbojam-demo-full.yml
+++ b/.github/workflows/turbojam-demo-full.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       target_name: turbojam
       docker_image: 'r2rationality/turbojam-fuzz:latest'
+      docker_memory: '8192m'
       spec: full
       num_blocks: 500
       mention: sierkov

--- a/.github/workflows/typeberry-demo-full.yml
+++ b/.github/workflows/typeberry-demo-full.yml
@@ -20,6 +20,7 @@ jobs:
       target_name: typeberry
       docker_image: 'ghcr.io/fluffylabs/typeberry:latest'
       docker_env: 'JAM_LOG=log'
+      docker_memory: '8192m'
       readiness_pattern: 'PVM Backend'
       spec: full
       num_blocks: 500

--- a/.github/workflows/vinwolf-demo-full.yml
+++ b/.github/workflows/vinwolf-demo-full.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       target_name: vinwolf
       docker_image: 'ghcr.io/bloppan/vinwolf:latest'
+      docker_memory: '8192m'
       readiness_pattern: 'listening on'
       spec: full
       num_blocks: 500


### PR DESCRIPTION
## Summary
- Bump performance memory limit to `2048m` for `spacejam` and `jambda` (mirrors the earlier `jamduna` bump in #43).
- Bump demo (full) memory limit to `8192m` for all 23 targets — adds `docker_memory: '8192m'` where it was unset (default 2048m) and raises explicit values that were below 8192m. `javajam` was already at 8192m and is unchanged.

## Test plan
- [ ] Manually trigger one of the demo (full) workflows via `workflow_dispatch` and confirm the target runs with the new memory limit.
- [ ] Manually trigger spacejam / jambda performance workflows and confirm the bumped limit takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased container memory allocations for demo and performance workflows to improve stability and reliability (most demo runs now use 8192m; some performance jobs use 2048m).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->