### PR TITLE
Bump default memory to 1G and storage timeouts to 15m

### DIFF
--- a/.github/workflows/reusable-picofuzz.yml
+++ b/.github/workflows/reusable-picofuzz.yml
@@ -24,7 +24,7 @@ on:
       docker_memory:
         required: false
         type: string
-        default: "512m"
+        default: "1024m"
         description: "Docker memory limit"
       docker_platform:
         required: false
@@ -87,7 +87,7 @@ jobs:
     needs: init
     name: "Minifuzz ${{ matrix.test }} (${{ inputs.target_name }})"
     runs-on: [self-hosted, perf]
-    timeout-minutes: ${{ inputs.timeout_minutes }}
+    timeout-minutes: ${{ (matrix.test == 'storage' || matrix.test == 'storage_light') && 15 || inputs.timeout_minutes }}
     strategy:
       fail-fast: true
       matrix:
@@ -110,7 +110,7 @@ jobs:
       - name: Run minifuzz ${{ matrix.test }}
         run: npm exec tsx -- --test tests/minifuzz/${{ matrix.test }}.test.ts
         env:
-          TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
+          TIMEOUT_MINUTES: ${{ (matrix.test == 'storage' || matrix.test == 'storage_light') && 15 || inputs.timeout_minutes }}
           TARGET_NAME: ${{ inputs.target_name }}
           TARGET_IMAGE: ${{ inputs.docker_image }}
           TARGET_CMD: ${{ inputs.docker_cmd }}
@@ -122,7 +122,7 @@ jobs:
     needs: [init, minifuzz]
     name: "Picofuzz ${{ matrix.test }} (${{ inputs.target_name }})"
     runs-on: [self-hosted, perf]
-    timeout-minutes: ${{ inputs.timeout_minutes }}
+    timeout-minutes: ${{ (matrix.test == 'storage' || matrix.test == 'storage_light') && 15 || inputs.timeout_minutes }}
     strategy:
       fail-fast: false
       matrix:
@@ -148,7 +148,7 @@ jobs:
       - name: Run picofuzz ${{ matrix.test }}
         run: npm exec tsx -- --test tests/picofuzz/${{ matrix.test }}.test.ts
         env:
-          TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
+          TIMEOUT_MINUTES: ${{ (matrix.test == 'storage' || matrix.test == 'storage_light') && 15 || inputs.timeout_minutes }}
           TARGET_NAME: ${{ inputs.target_name }}
           TARGET_IMAGE: ${{ inputs.docker_image }}
           TARGET_CMD: ${{ inputs.docker_cmd }}


### PR DESCRIPTION
## Summary
- Raise `docker_memory` default in `reusable-picofuzz.yml` from `512m` to `1024m`. The 15 performance workflows that don't override (boka, graymatter, jamixir, jampy, jampy-recompiler, jamzig, jamzilla, jamzilla-int, new-jamneration, pyjamaz, tessera, tsjam, turbojam, typeberry, vinwolf) get bumped to 1G; the 8 that already set ≥2048m keep their larger values.
- Extend `timeout-minutes` (job hard cap) and `TIMEOUT_MINUTES` (env var read by `getTimeoutMs`) to 15 for the `storage` and `storage_light` suites in both the minifuzz and picofuzz jobs. Other suites keep `inputs.timeout_minutes` (default 10).

## Test plan
- [ ] Trigger one performance workflow that does *not* override `docker_memory` (e.g. typeberry-performance) via `workflow_dispatch` and confirm `TARGET_MEMORY=1024m` in the docker run logs.
- [ ] Confirm storage / storage_light matrix legs report the 15m timeout in the GHA UI, while fallback / safrole / forks / no_forks legs still show 10m.
- [ ] Confirm a workflow that explicitly sets a higher memory (e.g. javajam-performance: 8192m) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test execution with dynamic timeout configuration for resource-intensive test suites.
  * Increased Docker memory allocation to 1024m for improved test performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->