### PR TITLE
jotl: remove legacy docker_cmd from workflows

### DIFF
--- a/.github/workflows/jotl-demo-tiny.yml
+++ b/.github/workflows/jotl-demo-tiny.yml
@@ -19,7 +19,6 @@ jobs:
     with:
       target_name: jotl
       docker_image: 'ghcr.io/polykrate/jotl:latest'
-      docker_cmd: '{TARGET_SOCK}'
       docker_memory: '2048m'
       readiness_pattern: 'Listening on'
       spec: tiny

--- a/.github/workflows/jotl-performance.yml
+++ b/.github/workflows/jotl-performance.yml
@@ -14,6 +14,5 @@ jobs:
     with:
       target_name: jotl
       docker_image: 'ghcr.io/polykrate/jotl:latest'
-      docker_cmd: '{TARGET_SOCK}'
       docker_memory: '2048m'
       readiness_pattern: 'Listening on'


### PR DESCRIPTION
## Summary
- Remove `docker_cmd: '{TARGET_SOCK}'` from `jotl-performance.yml` and `jotl-demo-tiny.yml`
- The jotl Docker image already follows standard packaging: it reads `JAM_FUZZ_SOCK_PATH` from env vars via `scripts/fuzz-target.sh`, so the legacy `docker_cmd` shim is unnecessary
- `jotl-demo-full.yml` already had no `docker_cmd` — this aligns the other two workflows

## Test plan
- [ ] Trigger `jotl-performance` via `workflow_dispatch` to verify it still works without `docker_cmd`
- [ ] Trigger `jotl-demo-tiny` via `workflow_dispatch` to verify it still works without `docker_cmd`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations for demo and performance testing environments. Refined initialization parameters and environment setup processes by simplifying configuration inputs and removing redundant parameters. These improvements enhance workflow efficiency, reduce setup complexity, and optimize the testing pipeline's reliability across deployment scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FluffyLabs/jam-testing/pull/63)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->