### PR TITLE
Fix deploy pipeline: retry artifact downloads, strict 4/4 filtering

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -45,9 +45,20 @@ jobs:
             for bench in $BENCHMARKS; do
               ARTIFACT="picofuzz-csv-${target}-${bench}"
               echo "Downloading ${ARTIFACT}..."
-              gh run download --repo "${{ github.repository }}" \
-                --name "$ARTIFACT" \
-                --dir "artifacts/${ARTIFACT}" 2>/dev/null || echo "  (not found, skipping)"
+              SUCCESS=false
+              for attempt in 1 2 3; do
+                if gh run download --repo "${{ github.repository }}" \
+                  --name "$ARTIFACT" \
+                  --dir "artifacts/${ARTIFACT}" 2>/dev/null; then
+                  SUCCESS=true
+                  break
+                fi
+                echo "  attempt $attempt failed, retrying in ${attempt}s..."
+                sleep "$attempt"
+              done
+              if [ "$SUCCESS" = false ]; then
+                echo "  (not found after 3 attempts, skipping)"
+              fi
             done
           done
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /picofuzz-result
 /benchmark-report.md
 /docs/
+/artifacts/
+/fuzz-perf/
 
 # Logs
 logs

--- a/scripts/csv-to-dashboard-json.cjs
+++ b/scripts/csv-to-dashboard-json.cjs
@@ -152,25 +152,21 @@ function main() {
     converted++;
   }
 
-  // Fill in missing required benchmarks with placeholder values so
-  // teams with partial results still appear in the dashboard.
+  // Log teams with missing benchmarks (they will be excluded from aggregation)
   const teamDirs = fs.existsSync(versionDir)
     ? fs.readdirSync(versionDir).filter(d => fs.statSync(path.join(versionDir, d)).isDirectory())
     : [];
 
-  let filled = 0;
   for (const team of teamDirs) {
-    for (const bench of REQUIRED_BENCHMARKS) {
-      const benchFile = path.join(versionDir, team, `${bench}.json`);
-      if (!fs.existsSync(benchFile)) {
-        fs.writeFileSync(benchFile, JSON.stringify(makePlaceholderJson(team), null, 2));
-        console.log(`  ${team}/${bench}.json (placeholder) ✓`);
-        filled++;
-      }
+    const missing = REQUIRED_BENCHMARKS.filter(bench =>
+      !fs.existsSync(path.join(versionDir, team, `${bench}.json`))
+    );
+    if (missing.length > 0) {
+      console.log(`  ${team}: missing ${missing.join(', ')} — will be excluded from rankings`);
     }
   }
 
-  console.log(`\nConverted ${converted} benchmark files, filled ${filled} placeholders in ${versionDir}`);
+  console.log(`\nConverted ${converted} benchmark files in ${versionDir}`);
 }
 
 main();

--- a/scripts/update-history.cjs
+++ b/scripts/update-history.cjs
@@ -54,13 +54,25 @@ function main() {
   for (const [version, data] of Object.entries(aggregated)) {
     snapshot.versions[version] = {
       baseline: data.baseline,
-      teams: data.teams.map(t => ({
-        name: t.name,
-        score: t.score,
-        rank: t.rank,
-        metrics: t.metrics,
-        relativeToBaseline: t.relativeToBaseline,
-      })),
+      teams: data.teams.map(t => {
+        const entry = {
+          name: t.name,
+          score: t.score,
+          rank: t.rank,
+          metrics: t.metrics,
+          relativeToBaseline: t.relativeToBaseline,
+        };
+        if (t.benchmarkScores) {
+          entry.benchmarkScores = {};
+          for (const [bm, info] of Object.entries(t.benchmarkScores)) {
+            entry.benchmarkScores[bm] = {
+              score: info.score ?? null,
+              metrics: info.metrics || null,
+            };
+          }
+        }
+        return entry;
+      }),
     };
   }
 


### PR DESCRIPTION
## Summary

- **deploy-dashboard.yml**: Add 3-attempt retry with progressive backoff (1s, 2s, 3s) on `gh run download` to handle transient GitHub API 502 errors during artifact pagination. With 3700+ artifacts in the repo, the API intermittently returns 502 during pagination — currently silently swallowed by `2>/dev/null`, causing valid artifacts to be skipped.
- **csv-to-dashboard-json.cjs**: Remove placeholder JSON generation (zero-value files) for missing benchmarks. Teams with incomplete traces are now excluded from rankings entirely, instead of getting artificially low scores calculated from 3/4 benchmarks.
- **update-history.cjs**: Include per-benchmark `benchmarkScores` (score + metrics per trace) in history snapshots, enabling per-trace trend analysis.

## Problem

The current `gh run download --name <artifact> 2>/dev/null || echo "(not found, skipping)"` pattern treats transient 502 errors identically to genuinely missing artifacts. This causes:

1. `csv-to-dashboard-json.cjs` creates placeholder JSONs with 0 values for the "missing" artifacts
2. `generate-aggregated-data.js` calculates scores using `geometricMean` which filters out zeros, giving teams a score based on fewer benchmarks (e.g., 3/4 instead of 4/4)
3. Affected teams get artificially better/worse rankings depending on which trace is missing

Verified locally: 5 teams currently affected by false positives (artifacts exist on GitHub but were missed by the pipeline). With the retry fix, all 5 are recovered — 4 artifacts needed a second attempt.

## Test plan

- [x] Local simulation of full artifact download with retry: 84/92 success, 0 false positives, 4 saved by retry
- [ ] Trigger manual `deploy-dashboard` workflow run after merge to verify corrected scores
- [ ] Verify history.json contains benchmarkScores in the new snapshot

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability with automatic retry logic for artifact downloads.
  * Teams with incomplete benchmark data are now properly excluded from rankings rather than filled with placeholder values.

* **Chores**
  * Updated build configuration to ignore artifact and performance testing directories.
  * Enhanced historical data storage to capture per-team benchmark scores.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FluffyLabs/jam-testing/pull/66)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->