### PR TITLE
Bump pyjamaz tiny fuzz memory to 8192m

### DIFF
--- a/.github/workflows/pyjamaz-demo-tiny.yml
+++ b/.github/workflows/pyjamaz-demo-tiny.yml
@@ -20,5 +20,6 @@ jobs:
       target_name: pyjamaz
       docker_image: 'jamdottech/pyjamaz:latest'
       docker_cmd: 'fuzzer target --db-path=/tmp/pyjamaz_fuzzer_db --socket-path={TARGET_SOCK}'
+      docker_memory: '8192m'
       spec: tiny
       mention: emielsebastiaan


### PR DESCRIPTION
## Summary
- Sets `docker_memory: '8192m'` on the pyjamaz tiny demo workflow (was falling back to the 2048m default in `demo-source.yml`), matching what other tiny targets use.

## Test plan
- [ ] Workflow YAML parses (next scheduled / manual run of `Demo (tiny): pyjamaz`).
- [ ] Container memory limit visible as 8192m in the run logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to allocate additional memory resources for demo execution, improving container performance and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FluffyLabs/jam-testing/pull/71)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->