### PR TITLE
Lower pyjamaz tiny fuzz memory to 4096m

### DIFF
--- a/.github/workflows/pyjamaz-demo-tiny.yml
+++ b/.github/workflows/pyjamaz-demo-tiny.yml
@@ -20,6 +20,6 @@ jobs:
       target_name: pyjamaz
       docker_image: 'jamdottech/pyjamaz:latest'
       docker_cmd: 'fuzzer target --db-path=/tmp/pyjamaz_fuzzer_db --socket-path={TARGET_SOCK}'
-      docker_memory: '8192m'
+      docker_memory: '4096m'
       spec: tiny
       mention: emielsebastiaan


### PR DESCRIPTION
## Summary
- Lowers `docker_memory` for the pyjamaz tiny demo fuzzing workflow from `8192m` to `4096m`.
- Follow-up to #71, which had bumped the limit from the 2048m default. 4096m is a middle ground that should still give pyjamaz enough headroom over the default while avoiding allocating 8GB to the container.

## Test plan
- [ ] Trigger `Demo (tiny): pyjamaz` via `workflow_dispatch` and verify the run completes without OOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker memory allocation for the demo environment to reduce resource consumption.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FluffyLabs/jam-testing/pull/74)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->