### PR TITLE
Force-remove containers after test runs to stop leaks

### DIFF
--- a/tests/common.ts
+++ b/tests/common.ts
@@ -1,5 +1,6 @@
 import type { ExecFileSyncOptions } from "node:child_process";
 import { execFileSync } from "node:child_process";
+import { CONTAINER_LABEL, registerContainer, uniqueName, unregisterContainer } from "./container-registry.js";
 import { ExternalProcess } from "./external-process.js";
 
 const SOCKET_PATH = "/shared/jam_target.sock";
@@ -52,6 +53,8 @@ const DOCKER_OPTIONS = (mem = "512m") => [
   "--stop-signal=SIGKILL",
   "--stop-timeout=5",
 ];
+
+const LABEL_ARGS = ["--label", CONTAINER_LABEL];
 
 export interface SourceConfig {
   name: string;
@@ -110,6 +113,21 @@ function docker(args: string[], options: ExecFileSyncOptions = {}) {
   return execFileSync("docker", args, options);
 }
 
+/**
+ * Run a short-lived `docker run --rm` helper with a tracked name so it gets
+ * force-removed on shutdown if it ever leaks (e.g. test runner SIGKILLed
+ * mid-call).
+ */
+function dockerRunHelper(role: string, args: string[], options: ExecFileSyncOptions = {}) {
+  const name = uniqueName(role);
+  registerContainer(name);
+  try {
+    return docker(["run", "--rm", "--name", name, ...LABEL_ARGS, ...args], options);
+  } finally {
+    unregisterContainer(name);
+  }
+}
+
 export function createSharedVolume(name = "") {
   const volumeName = `${SHARED_VOLUME}${name}`;
   // Clean up any existing volume and create a fresh one
@@ -122,9 +140,7 @@ export function createSharedVolume(name = "") {
 
   // Initialize the volume with proper permissions and prepare the
   // JAM_FUZZ_DATA_PATH directory used by standard target packaging.
-  docker([
-    "run",
-    "--rm",
+  dockerRunHelper("init", [
     "--network",
     "none",
     "-v",
@@ -172,10 +188,11 @@ async function waitForSocket(volumeName: string, maxWaitMs = 60_000): Promise<vo
   const deadline = Date.now() + maxWaitMs;
   while (Date.now() < deadline) {
     try {
-      docker(["run", "--rm", "--network", "none", "-v", `${volumeName}:/shared`, "alpine", "test", "-S", SOCKET_PATH], {
-        timeout: 5000,
-        stdio: "pipe",
-      });
+      dockerRunHelper(
+        "probe",
+        ["--network", "none", "-v", `${volumeName}:/shared`, "alpine", "test", "-S", SOCKET_PATH],
+        { timeout: 5000, stdio: "pipe" },
+      );
       // Socket exists, small delay for listen() to complete
       await new Promise((r) => setTimeout(r, 500));
       return;
@@ -191,10 +208,9 @@ async function waitForSocket(volumeName: string, maxWaitMs = 60_000): Promise<vo
  * Initialize starts from a clean cache, matching official testing behavior.
  */
 export function clearDataDir(volumeName: string) {
-  docker(
+  dockerRunHelper(
+    "cleardata",
     [
-      "run",
-      "--rm",
       "--network",
       "none",
       "-v",
@@ -209,10 +225,11 @@ export function clearDataDir(volumeName: string) {
 }
 
 export function chmodSocket(volumeName: string) {
-  docker(["run", "--rm", "--network", "none", "-v", `${volumeName}:/shared`, "alpine", "chmod", "777", SOCKET_PATH], {
-    timeout: 10_000,
-    stdio: "pipe",
-  });
+  dockerRunHelper(
+    "chmod",
+    ["--network", "none", "-v", `${volumeName}:/shared`, "alpine", "chmod", "777", SOCKET_PATH],
+    { timeout: 10_000, stdio: "pipe" },
+  );
 }
 
 export async function startTarget({
@@ -226,12 +243,17 @@ export async function startTarget({
 }) {
   const envArgs = buildTargetEnvArgs(config.env);
   const cmdArgs = buildCmdArgs(config.cmd);
+  const containerName = uniqueName(`target-${config.name}`);
 
-  const proc = ExternalProcess.spawn(
+  const proc = ExternalProcess.spawnWithContainer(
     config.name,
+    containerName,
     "docker",
     "run",
     "--rm",
+    "--name",
+    containerName,
+    ...LABEL_ARGS,
     ...envArgs,
     ...DOCKER_OPTIONS(config.memory),
     "-v",
@@ -261,11 +283,16 @@ export async function minifuzz({
   sharedVolume?: string;
   timeout: number;
 }) {
-  return ExternalProcess.spawn(
+  const containerName = uniqueName("minifuzz");
+  return ExternalProcess.spawnWithContainer(
     "minifuzz",
+    containerName,
     "docker",
     "run",
     "--rm",
+    "--name",
+    containerName,
+    ...LABEL_ARGS,
     "--network",
     "none",
     "-v",
@@ -297,12 +324,17 @@ export async function fuzzSource({
 }) {
   const cmdArgs = buildCmdArgs(config.cmd);
   const userArgs = config.user ? ["--user", config.user] : [];
+  const containerName = uniqueName(`source-${config.name}`);
 
-  return ExternalProcess.spawn(
+  return ExternalProcess.spawnWithContainer(
     config.name,
+    containerName,
     "docker",
     "run",
     "--rm",
+    "--name",
+    containerName,
+    ...LABEL_ARGS,
     ...userArgs,
     ...DOCKER_OPTIONS(config.memory),
     "-v",
@@ -327,11 +359,16 @@ export async function picofuzz({
   statsFile?: string;
   ignore?: string[];
 }) {
-  return ExternalProcess.spawn(
+  const containerName = uniqueName("picofuzz");
+  return ExternalProcess.spawnWithContainer(
     "picofuzz",
+    containerName,
     "docker",
     "run",
     "--rm",
+    "--name",
+    containerName,
+    ...LABEL_ARGS,
     "--network",
     "none",
     "-v",

--- a/tests/container-registry.ts
+++ b/tests/container-registry.ts
@@ -1,0 +1,84 @@
+import { execFileSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+
+/**
+ * Containers we have started in this process. Tracked so we can force-remove
+ * them on shutdown even if the docker CLI client has been SIGKILLed (which
+ * orphans the container under dockerd — `--rm` never fires in that case).
+ */
+const knownContainers = new Set<string>();
+
+export const CONTAINER_LABEL = "jam-testing=1";
+
+export function uniqueName(role: string): string {
+  const suffix = randomBytes(4).toString("hex");
+  return `jam-test-${role}-${process.pid}-${suffix}`;
+}
+
+export function registerContainer(name: string): void {
+  knownContainers.add(name);
+}
+
+export function unregisterContainer(name: string): void {
+  knownContainers.delete(name);
+}
+
+/**
+ * Synchronously force-remove a container and drop it from the registry.
+ * Best-effort: swallows errors (container may already be gone).
+ */
+export function removeContainer(name: string): void {
+  knownContainers.delete(name);
+  try {
+    execFileSync("docker", ["rm", "-f", name], {
+      stdio: "pipe",
+      timeout: 10_000,
+    });
+  } catch {
+    // container may already be removed, or docker unreachable
+  }
+}
+
+/**
+ * Synchronously force-remove all tracked containers. Used by exit handlers.
+ */
+function removeAllTracked(): void {
+  if (knownContainers.size === 0) return;
+  const names = Array.from(knownContainers);
+  knownContainers.clear();
+  try {
+    execFileSync("docker", ["rm", "-f", ...names], {
+      stdio: "pipe",
+      timeout: 15_000,
+    });
+  } catch {
+    // best-effort
+  }
+}
+
+let handlersInstalled = false;
+
+export function installShutdownHandlers(): void {
+  if (handlersInstalled) return;
+  handlersInstalled = true;
+
+  process.on("exit", removeAllTracked);
+
+  // SIGINT / SIGTERM: do sync cleanup, then exit with conventional signal code.
+  // Registering a listener disables Node's default exit-on-signal behavior, so
+  // we must call process.exit ourselves.
+  const onSignal = (signal: NodeJS.Signals) => {
+    removeAllTracked();
+    process.exit(signal === "SIGINT" ? 130 : 143);
+  };
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+
+  process.on("uncaughtException", (err) => {
+    console.error("Uncaught exception, cleaning up containers:", err);
+    removeAllTracked();
+    process.exit(1);
+  });
+}
+
+installShutdownHandlers();

--- a/tests/external-process.ts
+++ b/tests/external-process.ts
@@ -1,10 +1,26 @@
 import { type ChildProcessWithoutNullStreams, execSync, spawn } from "node:child_process";
 import { promises, setTimeout } from "node:timers";
+import { registerContainer, removeContainer, unregisterContainer } from "./container-registry.js";
 
-const SHUTDOWN_GRACE_PERIOD = 15_000;
+const SHUTDOWN_GRACE_PERIOD = 5_000;
 
 export class ExternalProcess {
-  static spawn(processName: string, command: string, ...args: string[]) {
+  static spawn(processName: string, command: string, ...args: string[]): ExternalProcess {
+    return ExternalProcess.spawnWithContainer(processName, undefined, command, ...args);
+  }
+
+  /**
+   * Like spawn, but tags the process with a docker container name. The name is
+   * registered with the container registry so it can be force-removed on
+   * shutdown — guarding against orphaned containers when the docker CLI client
+   * is SIGKILLed and `--rm` never fires.
+   */
+  static spawnWithContainer(
+    processName: string,
+    containerName: string | undefined,
+    command: string,
+    ...args: string[]
+  ): ExternalProcess {
     console.log(`Spawning ${processName}: "${command} ${args.join(" ")}"`);
     const spawned = spawn(command, args, {
       cwd: process.cwd(),
@@ -15,7 +31,10 @@ export class ExternalProcess {
     spawned.stderr.on("data", (data: Buffer) => {
       console.error(`[${processName}] ${data.toString()}`);
     });
-    return new ExternalProcess(processName, spawned, args);
+    if (containerName) {
+      registerContainer(containerName);
+    }
+    return new ExternalProcess(processName, spawned, args, containerName);
   }
 
   public readonly cleanExit: Promise<void>;
@@ -25,13 +44,16 @@ export class ExternalProcess {
     private readonly processName: string,
     private readonly spawned: ChildProcessWithoutNullStreams,
     private readonly args: string[],
+    private readonly containerName: string | undefined,
   ) {
     this.cleanExit = new Promise((resolve, reject) => {
       spawned.on("error", (err) => {
+        if (containerName) unregisterContainer(containerName);
         reject(`[${this.processName}] Failed to start process: ${err.message}`);
       });
 
       spawned.on("exit", (code, signal) => {
+        if (containerName) unregisterContainer(containerName);
         if (code === 0) {
           resolve();
         } else if (this.killedIntentionally) {
@@ -63,14 +85,15 @@ export class ExternalProcess {
 
     // Find the container image and try to get memory stats from dmesg
     try {
-      const dmesg = execSync("dmesg --time-format iso 2>/dev/null | tail -30 || journalctl -k -n 30 --no-pager 2>/dev/null || true", {
-        timeout: 5_000,
-        encoding: "utf-8",
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-      const oomLines = dmesg
-        .split("\n")
-        .filter((line) => /oom|out of memory|killed process/i.test(line));
+      const dmesg = execSync(
+        "dmesg --time-format iso 2>/dev/null | tail -30 || journalctl -k -n 30 --no-pager 2>/dev/null || true",
+        {
+          timeout: 5_000,
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+        },
+      );
+      const oomLines = dmesg.split("\n").filter((line) => /oom|out of memory|killed process/i.test(line));
       if (oomLines.length > 0) {
         return `\nKernel OOM messages:\n${oomLines.join("\n")}`;
       }
@@ -98,17 +121,27 @@ export class ExternalProcess {
   }
 
   async terminate() {
-    if (this.spawned.killed) {
-      console.warn("Process already terminated. Ignoring.");
+    if (this.killedIntentionally) {
+      console.warn(`[${this.processName}] Already terminating. Ignoring.`);
+      return;
     }
-
     this.killedIntentionally = true;
     console.log(`[${this.processName}] Terminating`);
-    const grace = promises.setTimeout(SHUTDOWN_GRACE_PERIOD);
+
+    // Force-remove the container directly via dockerd. Don't rely on signal
+    // forwarding through the local CLI client — that's unreliable (SIGKILL on
+    // the CLI just orphans the container).
+    if (this.containerName) {
+      removeContainer(this.containerName);
+    }
+
+    // Then wind down the local CLI process.
     this.spawned.stdin?.end();
     this.spawned.stdout?.destroy();
     this.spawned.stderr?.destroy();
     this.spawned.kill("SIGTERM");
+
+    const grace = promises.setTimeout(SHUTDOWN_GRACE_PERIOD);
     await grace;
     if (this.spawned.exitCode === null) {
       console.error(`[${this.processName}] shutdown timing out. Killing`);


### PR DESCRIPTION
## Summary

After a failed/timed-out job, target containers were surviving on the
runner (some 6–8 hours old, see attached screenshot in the issue). Root
cause: `terminate()` relies on signal propagation through the local
`docker run` CLI client. When that client is SIGKILLed (timeout, OOM,
cancelled job), dockerd keeps the container running and `--rm` never
fires.

This PR stops trusting signal propagation and removes containers
directly via dockerd:

- Tag every `docker run` (target, source, picofuzz, minifuzz, and the
  short-lived alpine helpers) with a unique `--name jam-test-<role>-<pid>-<rand>`
  and `--label jam-testing=1`.
- In `ExternalProcess.terminate()`, call `docker rm -f <name>` first,
  then wind down the local CLI with a shorter grace.
- New `tests/container-registry.ts` tracks active container names and
  installs `exit`/`SIGINT`/`SIGTERM`/`uncaughtException` handlers that
  sync force-remove every tracked container before the process exits.

If something ever escapes anyway, ops can wipe survivors in one
command thanks to the label:

```sh
docker rm -f $(docker ps -aq --filter label=jam-testing=1)
```

## Notes

- No boot-time sweep was added (intentionally — would interfere with
  any concurrent run on the same host). The label-based manual command
  above covers the residual case.
- Pre-existing biome formatting errors in `tests/minifuzz/common.ts`
  are unrelated and untouched.

## Test plan

- [ ] `npm run build` (typecheck) passes
- [ ] Run any team's picofuzz test, let it complete, confirm no
      `jam-testing` labeled containers remain
- [ ] Cancel a running test (Ctrl-C / `kill <pid>`), confirm all
      labeled containers are removed
- [ ] SIGKILL the test runner mid-run; expected: containers leak (no
      handler runs), but `docker ps --filter label=jam-testing=1`
      identifies them for manual cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Implemented centralized Docker container tracking to ensure reliable cleanup of test containers during and after test execution.
  * Enhanced external process spawning with integrated container lifecycle management and automatic resource cleanup on process termination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FluffyLabs/jam-testing/pull/76)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->