### PR TITLE
Bump typeberry long-running fuzz to 100k blocks per spec

### DIFF
--- a/.github/workflows/typeberry-fuzz.yml
+++ b/.github/workflows/typeberry-fuzz.yml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - spec: tiny
-            num_blocks: 5000
+            num_blocks: 100000
           - spec: full
-            num_blocks: 500
+            num_blocks: 100000
     uses: ./.github/workflows/graymatter-fuzz-source.yml
     with:
       target_name: typeberry
@@ -28,7 +28,7 @@ jobs:
       docker_env: 'JAM_LOG=log'
       readiness_pattern: 'PVM Backend'
       spec: ${{ matrix.spec }}
-      timeout_minutes: 30
+      timeout_minutes: 1380
       num_blocks: ${{ matrix.num_blocks }}
-      num_runs: 9
+      num_runs: 1
       mention: tomusdrw


### PR DESCRIPTION
## Summary
- Increase typeberry long-running fuzz to `num_blocks: 100000` for both `tiny` and `full` specs.
- Drop `num_runs` from 9 to 1 (single straight pass per spec instead of repeated source restarts).
- Raise `timeout_minutes` from 30 to 1380 (23h), matching the precedent in `turbojam-fuzz.yml`.

## Test plan
- [ ] Manual `workflow_dispatch` run on `tiny` completes within the new timeout.
- [ ] Manual `workflow_dispatch` run on `full` completes within the new timeout (this one is the risk — `full` was previously ~10× slower per block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated fuzz testing workflow configuration parameters to optimize testing execution and coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FluffyLabs/jam-testing/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->